### PR TITLE
Add multi-platform build support

### DIFF
--- a/.github/workflows/push-image.yml
+++ b/.github/workflows/push-image.yml
@@ -34,12 +34,13 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and Push Docker Image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         env:
           DOCKER_BUILDKIT: 1
         with:
           context: .
           file: Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
-FROM --platform=$BUILDPLATFORM golang:1.25 AS builder
-ARG TARGETOS
-ARG TARGETARCH
+FROM golang:1.25 AS builder
 WORKDIR /app
+
 COPY main.go .
 RUN go mod init helm-scraper && go mod tidy
 RUN CGO_ENABLED=0 \
@@ -11,6 +10,9 @@ RUN CGO_ENABLED=0 \
 
 FROM alpine:latest
 WORKDIR /root/
+
+#ENV CLUSTER_NAME="minikube"
 COPY --from=builder /app/helm-scraper /root/helm-scraper
 RUN chmod +x /root/helm-scraper
+
 ENTRYPOINT ["/root/helm-scraper"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23 AS builder
+FROM golang:1.25 AS builder
 WORKDIR /app
 
 COPY main.go .

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,7 @@ WORKDIR /app
 
 COPY main.go .
 RUN go mod init helm-scraper && go mod tidy
-RUN CGO_ENABLED=0 \
-    GOOS=$TARGETOS \
-    GOARCH=$TARGETARCH \
-    go build -o helm-scraper main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o helm-scraper main.go
 
 FROM alpine:latest
 WORKDIR /root/

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,10 @@ WORKDIR /app
 
 COPY main.go .
 RUN go mod init helm-scraper && go mod tidy
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o helm-scraper main.go
+RUN CGO_ENABLED=0 \
+    GOOS=$TARGETOS \
+    GOARCH=$TARGETARCH \
+    go build -o helm-scraper main.go
 
 FROM alpine:latest
 WORKDIR /root/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25 AS builder
+FROM golang:1.23 AS builder
 WORKDIR /app
 
 COPY main.go .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
-FROM golang:1.25 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25 AS builder
+ARG TARGETOS
+ARG TARGETARCH
 WORKDIR /app
-
 COPY main.go .
 RUN go mod init helm-scraper && go mod tidy
 RUN CGO_ENABLED=0 \
@@ -10,9 +11,6 @@ RUN CGO_ENABLED=0 \
 
 FROM alpine:latest
 WORKDIR /root/
-
-#ENV CLUSTER_NAME="minikube"
 COPY --from=builder /app/helm-scraper /root/helm-scraper
 RUN chmod +x /root/helm-scraper
-
 ENTRYPOINT ["/root/helm-scraper"]


### PR DESCRIPTION
- build amd64 and arm64 images
- bump go version to 1.25
- bump docker/build-push-action to v6  